### PR TITLE
Fix: Fixed user and group association and updated members naming

### DIFF
--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -2,8 +2,8 @@ class Group < ApplicationRecord
 
   # Associations
   belongs_to :admin, class_name: "User", foreign_key: :admin_id
-  has_many :members
-  has_many :users, through: :members
+  has_many :memberships
+  has_many :users, through: :memberships
   has_many :tasks
   has_many :tags
   has_many :invitations
@@ -13,18 +13,18 @@ class Group < ApplicationRecord
   validates :description, length: { maximum: 30 }
 
 
-  after_create :create_member
+  after_create :create_membership
 
   # Return the total members of a group
-  def total_members
-    self.members.count
+  def total_memberships
+    self.memberships.count
   end
 
   private
   
   # So that the group's admin becomes also a member of the group
-  def create_member
+  def create_membership
     user = self.admin
-    Member.create!(user: user, group: self)
+    Membership.create!(user: user, group: self)
   end
 end

--- a/api/app/models/membership.rb
+++ b/api/app/models/membership.rb
@@ -1,4 +1,4 @@
-class Member < ApplicationRecord
+class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :group
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -5,9 +5,9 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: self
 
   # Associations
-  has_many :groups, foreign_key: :admin_id, dependent: :destroy # If we delete the user (if admin), then the group will be also deleted
-  has_many :members
-  has_many :groups, through: :members
+  has_many :groups_as_admin, foreign_key: :admin_id, class_name: "Group", dependent: :destroy # If we delete the user (if admin), then the group will be also deleted
+  has_many :memberships
+  has_many :groups, through: :memberships
   has_many :tasks
   has_many :tasks, foreign_key: :assignee_id # Tasks will have one assignee per task
   has_many :tags

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   # Devise requires a default url
   host = 'localhost:3000'
   config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
-  config.action_mailer.delivery_method = :smtp #change to test in order not to send in the future
+  config.action_mailer.delivery_method = :test #change to test in order not to send in the future
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default :charset => "utf-8"

--- a/api/db/migrate/20230212085129_change_members_table_name.rb
+++ b/api/db/migrate/20230212085129_change_members_table_name.rb
@@ -1,0 +1,5 @@
+class ChangeMembersTableName < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :members, :memberships
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_212724) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_12_085129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,13 +44,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_212724) do
     t.index ["jti"], name: "index_jwt_denylist_on_jti"
   end
 
-  create_table "members", force: :cascade do |t|
+  create_table "memberships", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["group_id"], name: "index_members_on_group_id"
-    t.index ["user_id"], name: "index_members_on_user_id"
+    t.index ["group_id"], name: "index_memberships_on_group_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "tagged_tasks", force: :cascade do |t|
@@ -107,8 +107,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_212724) do
   add_foreign_key "invitations", "groups"
   add_foreign_key "invitations", "users", column: "recipient_id"
   add_foreign_key "invitations", "users", column: "sender_id"
-  add_foreign_key "members", "groups"
-  add_foreign_key "members", "users"
+  add_foreign_key "memberships", "groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "tagged_tasks", "tags"
   add_foreign_key "tagged_tasks", "tasks"
   add_foreign_key "tags", "groups"

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -15,8 +15,8 @@ Tag.destroy_all
 puts "Destroy Tasks"
 Task.destroy_all
 
-puts "Destroy Members"
-Member.destroy_all
+puts "Destroy Memberships"
+Membership.destroy_all
 
 puts "Destroy Invitations"
 Invitation.destroy_all
@@ -29,8 +29,8 @@ User.destroy_all
 
 puts "Creating Users"
 admin_one = User.create!(username: "jose", email: "jgarciaportillo@gmail.com", password: "123456")
-# user_one = User.create!(username: "saki", email: "saki@test.io", password: "1234567")
-# admin_two = User.create!(username: "joe", email: "joe@test.io", password: "1234567")
+user_one = User.create!(username: "saki", email: "saki@test.io", password: "1234567")
+admin_two = User.create!(username: "joe", email: "joe@test.io", password: "1234567")
 
 # user_two = User.create!(username: "Jose", email: "joes@test.io", password: "1234567") # Test if case sensitive works for username
 # user_three = User.create!(username: "jjose", email: "Joe@test.io", password: "1234567") # Test if case sensitive works for email
@@ -39,17 +39,17 @@ admin_one = User.create!(username: "jose", email: "jgarciaportillo@gmail.com", p
 
 puts "Creating Group"
 group_one = Group.create!(name: "Test Group One", description: "blablabla", admin: admin_one)
-# group_two = Group.create!(name: "Test Group Two", description: "blablabla", admin: admin_two)
+group_two = Group.create!(name: "Test Group Two", description: "blablabla", admin: admin_two)
 
 # group_three = Group.create!(description: "blablabla", admin: admin_two) # Test no presence of name
 # group_four = Group.create!(name: "Test Group Two ñalsdfjadlskfjasdñlfkadsjfañlsdkfjasdlñkfdajsñlfkdasjfdaslfkds", description: "blablabla", admin: admin_two) # Test name too long
 # group_four = Group.create!(name: "Test Group Three", description: "ñalsdfjadlskfjasdñlfkadsjfañlsdkfjasdlñkfdajsñlfkdasjfdaslfkds", admin: admin_two) # Test desc too long
 
-puts "Creating Members"
-# participant_one = Member.create!(user: user_one, group: group_one) # I can add any user to any group
+puts "Creating Memberships"
+participant_one = Membership.create!(user: user_one, group: group_one) # I can add any user to any group
 
 puts "Creating Tasks"
-# task_one = Task.create!(name: "Task 1", user: user_one, group: group_one, assignee: admin_one, due_date: "03/12/2024") 
+task_one = Task.create!(name: "Task 1", user: user_one, group: group_one, assignee: admin_one, due_date: "03/12/2024") 
 task_two = Task.create!(name: "Task 2", user: admin_one, group: group_one, assignee: admin_one, due_date: "24/12/30")
 
 # task_two = Task.create!(name: "Task 3", user: admin_one, group: group_two, assignee: user_one) # Test if we can create tasks for users not part of the group
@@ -59,24 +59,23 @@ task_two = Task.create!(name: "Task 2", user: admin_one, group: group_one, assig
 # task_two = Task.create!(name: "Task 2", user: admin_one, group: group_one, assignee: admin_one, due_date: "12/24/2030") # Test due date format
 
 puts "Creating Tags"
-# tag_one = Tag.create!(name: "Tag 1", user: user_one, group: group_one)
+tag_one = Tag.create!(name: "Tag 1", user: user_one, group: group_one)
 tag_two = Tag.create!(name: "Tag 2", user: admin_one, group: group_one)
-# Test if we can create tags even if user not part of the group
-# tag_three = Tag.create!(name: "Tag 3", user: admin_one, group: group_two)
-# tag_four =  Tag.create!(name: "Tag 4", user: admin_two, group: group_two)
+tag_three = Tag.create!(name: "Tag 3", user: admin_two, group: group_two)
+
+# tag_four = Tag.create!(name: "Tag 4", user: admin_one, group: group_two) # Test if we can create tags even if user not part of the group
 # tag_one = Tag.create!(user: user_one, group: group_one) # Test no name
 # tag_two = Tag.create!(name: "Tag  ñalskdfjads l ñalksdf jasd laksdjf añslkdfj", user: admin_one, group: group_one) # Test name too long
 
 puts "Creating TaggedTasks"
 taggedtask_one = TaggedTask.create!(task: task_two, tag: tag_two)
-# Test if we can create taggedtasks even if tag not part of the group
-# taggedtask_two = TaggedTask.create!(task: task_one, tag: tag_four) 
+
+# taggedtask_two = TaggedTask.create!(task: task_one, tag: tag_four) # Test if we can create taggedtasks even if tag not part of the group
 
 puts "Creating Invitations"
-# invitation_one = Invitation.create!(sender: admin_one, group: group_one, email: "abc@test.io")
-# Test if we can create invitations even if sender not part of the group
-# invitation_two = Invitation.create!(sender: admin_one, group: group_two)
-# Test if we can create invitations even if sender not admin
-# invitation_three = Invitation.create!(sender: user_one, group: group_one)
+invitation_one = Invitation.create!(sender: admin_one, group: group_one, email: "abc@test.io")
+
+# invitation_two = Invitation.create!(sender: admin_one, group: group_two) # Test if we can create invitations even if sender not part of the group
+# invitation_three = Invitation.create!(sender: user_one, group: group_one) # Test if we can create invitations even if sender not admin
 # invitation_two = Invitation.create!(sender: admin_one, group: group_one) # Test no email
 # invitation_three = Invitation.create!(sender: admin_one, group: group_one, email: "abctest.io") # Test email wrong format

--- a/api/test/models/membership_test.rb
+++ b/api/test/models/membership_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class MemberTest < ActiveSupport::TestCase
+class MembershipTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
- Updated user and group association
- Updated `Member` table naming to `Membership`
- Changed mailer to `test`
- Commented out `seeds` now that mailer will not send mail 