### PR TITLE
Feature: add requests specs

### DIFF
--- a/api/app/controllers/api/v1/groups_controller.rb
+++ b/api/app/controllers/api/v1/groups_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::GroupsController < ApplicationController
   before_action :find_group, only: [ :send_invitation ]
 
   def index
-    render json: { status: 200, message: "Hello World!"}
+    render json: { message: "Hello World!"}
   end
 
   # Sends invitation

--- a/api/app/controllers/api/v1/groups_controller.rb
+++ b/api/app/controllers/api/v1/groups_controller.rb
@@ -11,8 +11,7 @@ class Api::V1::GroupsController < ApplicationController
     if current_user.admin?
       @invitation.sender = current_user
       @invitation.group = @group
-      @invitation.save
-      InvitationMailer.with(recipient: @invitation.email, sender: @invitation.sender, group: @invitation.group).send_invite.deliver_later
+      InvitationMailer.with(recipient: @invitation.email, sender: @invitation.sender, group: @invitation.group).send_invite.deliver_later if @invitation.save
     else
       render_permission_error
     end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -2,11 +2,11 @@ class Group < ApplicationRecord
 
   # Associations
   belongs_to :admin, class_name: "User", foreign_key: :admin_id
-  has_many :memberships
+  has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
-  has_many :tasks
-  has_many :tags
-  has_many :invitations
+  has_many :tasks, dependent: :destroy
+  has_many :tags, dependent: :destroy
+  has_many :invitations, dependent: :destroy
 
   # Validations
   validates :name, presence: true, length: { in: 2..15 }

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -6,7 +6,7 @@ class Tag < ApplicationRecord
   has_many :tagged_tasks, dependent: :destroy
 
   # Validations
-  validates :name, presence: true, length: { maximum: 15 }
+  validates :name, presence: true, length: { maximum: 15 }, uniqueness: { case_sensitive: false, scope: :group_id }
 
   # validate :tag_validation
 

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -3,7 +3,7 @@ class Tag < ApplicationRecord
   # Associations
   belongs_to :group
   belongs_to :user
-  has_many :tagged_tasks
+  has_many :tagged_tasks, dependent: :destroy
 
   # Validations
   validates :name, presence: true, length: { maximum: 15 }

--- a/api/app/models/task.rb
+++ b/api/app/models/task.rb
@@ -4,7 +4,7 @@ class Task < ApplicationRecord
   belongs_to :group
   belongs_to :user
   belongs_to :assignee, class_name: "User", foreign_key: :assignee_id
-  has_many :tagged_tasks
+  has_many :tagged_tasks, dependent: :destroy
 
   # Validations
   validates :name, presence: true, length: { maximum: 25 }

--- a/api/app/models/task.rb
+++ b/api/app/models/task.rb
@@ -7,7 +7,7 @@ class Task < ApplicationRecord
   has_many :tagged_tasks, dependent: :destroy
 
   # Validations
-  validates :name, presence: true, length: { maximum: 25 }
+  validates :name, presence: true, length: { maximum: 25 }, uniqueness: { case_sensitive: false, scope: :group_id }
   validates :due_date, date: true 
   
   # validate :valid_task?

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,27 +13,21 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :users, only: [:update] do
-        member do
-          get 'search_tasks/:search_id' => 'users#search_tasks'
-        end
-      end
-
+      resources :users, only: [:update] 
       resources :groups, only: [:index, :show, :create, :update, :destroy] do
         member do
-          post 'send_invitation' => 'groups#send_invitation'
-          get 'fetch_group_users' => 'groups#fetch_group_users'
-          get 'filter_tasks' => 'groups#filter_tasks'
-          delete "remove_user/:user_id" => "groups#remove_user"
+          post 'send_invitation', to: 'groups#send_invitation'
+          get 'fetch_group_users', to: 'groups#fetch_group_users'
+          get 'filter_tasks', to: 'groups#filter_tasks'
+          delete "remove_user/:user_id", to: "groups#remove_user"
         end
         resources :tasks, only: [:index, :create], module: :groups
         resources :tags, only: [:index, :create, :update, :destroy]
         resources :invitations, only: [:index]
       end
-
       resources :tasks, only: [:index, :show, :create, :update, :destroy]
-
-      get 'invitation_signup/:token' => 'invitations#invitation_signup'
+      get 'invitation_signup/:token', to: 'invitations#invitation_signup'
+      get 'search_tasks/:search_id', to: 'users#search_tasks', as: :search_user_tasks
     end
   end
   mount Sidekiq::Web => '/sidekiq'

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -17,13 +17,13 @@ Rails.application.routes.draw do
       resources :groups, only: [:index, :show, :create, :update, :destroy] do
         member do
           post 'send_invitation', to: 'groups#send_invitation'
-          get 'fetch_group_users', to: 'groups#fetch_group_users'
           get 'filter_tasks', to: 'groups#filter_tasks'
           delete "remove_user/:user_id", to: "groups#remove_user", as: :remove_group_user
         end
         resources :tasks, only: [:index, :create], module: :groups
         resources :tags, only: [:index, :create, :update, :destroy]
         resources :invitations, only: [:index]
+        resources :users, only: [:index]
       end
       resources :tasks, only: [:index, :show, :create, :update, :destroy]
       get 'invitation_signup/:token', to: 'invitations#invitation_signup'

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
           post 'send_invitation', to: 'groups#send_invitation'
           get 'fetch_group_users', to: 'groups#fetch_group_users'
           get 'filter_tasks', to: 'groups#filter_tasks'
-          delete "remove_user/:user_id", to: "groups#remove_user"
+          delete "remove_user/:user_id", to: "groups#remove_user", as: :remove_group_user
         end
         resources :tasks, only: [:index, :create], module: :groups
         resources :tags, only: [:index, :create, :update, :destroy]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,11 +13,26 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :groups, only: [ :index ] do
+      resources :users, only: [:update] do
         member do
-          post 'send_invitation' => 'groups#send_invitation'
+          get 'search_tasks/:search_id' => 'users#search_tasks'
         end
       end
+
+      resources :groups, only: [:index, :show, :create, :update, :destroy] do
+        member do
+          post 'send_invitation' => 'groups#send_invitation'
+          get 'fetch_group_users' => 'groups#fetch_group_users'
+          get 'filter_tasks' => 'groups#filter_tasks'
+          delete "remove_user/:user_id" => "groups#remove_user"
+        end
+        resources :tasks, only: [:index, :create], module: :groups
+        resources :tags, only: [:index, :create, :update, :destroy]
+        resources :invitations, only: [:index]
+      end
+
+      resources :tasks, only: [:index, :show, :create, :update, :destroy]
+
       get 'invitation_signup/:token' => 'invitations#invitation_signup'
     end
   end

--- a/api/spec/factories/groups.rb
+++ b/api/spec/factories/groups.rb
@@ -4,5 +4,12 @@ FactoryBot.define do
 
     sequence(:name) { |n| "group_test#{n}" }
     description { "This is a test group" }
+
+    # Callback to create a task, tag, tagged_task and invitations associated to this group
+    after(:create) do |group| 
+      create_list(:task, 3, group: group, user: group.admin)
+      create(:tag, group: group, user: group.admin)
+      create(:invitation, group: group, sender: group.admin)
+    end
   end
 end

--- a/api/spec/factories/memberships.rb
+++ b/api/spec/factories/memberships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :membership do
+    association :user
+    association :group
+  end
+end

--- a/api/spec/factories/tagged_tasks.rb
+++ b/api/spec/factories/tagged_tasks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tagged_task do
+    association :tag
+    association :task
+  end
+end

--- a/api/spec/factories/tags.rb
+++ b/api/spec/factories/tags.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     association :user
     association :group
 
-    name { "Factory tag" }
+    sequence(:name) { |n| "Factory tag #{n}" }
   end
 end

--- a/api/spec/factories/tasks.rb
+++ b/api/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     association :assignee, factory: :user
 
     sequence(:name) { |n| "Factory task #{n}" }
+    finished { false }
     due_date { "24/07/2050" }
   end
 end

--- a/api/spec/factories/tasks.rb
+++ b/api/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :group
     association :assignee, factory: :user
 
-    name { "Factory task" }
+    sequence(:name) { |n| "Factory task #{n}" }
     due_date { "24/07/2050" }
   end
 end

--- a/api/spec/models/group_spec.rb
+++ b/api/spec/models/group_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Group, type: :model do
         expect(membership.user).to eq(subject.admin)
       end
     end
+
+    context "when group is edited" do
+      it "doesn't create a new membership" do
+        subject.name = "Group 2"
+        expect { subject.save! }.to_not change { Membership.count }
+      end
+    end
   end
 
   describe "#total_memberships" do

--- a/api/spec/models/tag_spec.rb
+++ b/api/spec/models/tag_spec.rb
@@ -29,7 +29,15 @@ RSpec.describe Tag, type: :model do
 
     context "when tag is created" do
       it "creates tag slug" do
-        expect(subject.slug).to eq("factory_tag")
+        expect subject.slug.to eq("factory_tag_#{subject.id}")
+      end
+    end
+
+    context "when tag is edited" do
+      it "updates tag slug" do
+        subject.name = "Factory Tag 2"
+        subject.save!
+        expect(subject.slug).to eq("factory_tag_2")
       end
     end
   end

--- a/api/spec/models/tag_spec.rb
+++ b/api/spec/models/tag_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
   describe "model validation" do
-
-    subject { create :tag }
+    let(:first_tag) { create :tag, name: "Factory tag"}
+    subject { create :tag, name: first_tag.name }
 
     context "when not valid" do     
       it "lacks name" do
@@ -16,6 +16,11 @@ RSpec.describe Tag, type: :model do
         subject.name = "Lorem ipsum dolor sit amet"
         expect(subject).to_not be_valid
         expect(subject.errors["name"]).to include("is too long (maximum is 15 characters)")
+      end
+
+      it "has duplicated name in a group" do 
+        let(:second_tag) { create :tag, name: subject.name, group: subject.group}
+        expect(second_tag).to_not be_valid
       end
     end
 

--- a/api/spec/models/task_spec.rb
+++ b/api/spec/models/task_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe "model validation" do
-    subject { create :task }
+    let(:first_task) { create :task, name: "Factory task"}
+    subject { create :task, name: first_task.name }
 
     context "when not valid" do     
       it "lacks name" do
@@ -25,6 +26,11 @@ RSpec.describe Task, type: :model do
       it "has invalid formatted date" do 
         subject.due_date = "07/25/2050"
         expect(subject).to_not be_valid
+      end
+      
+      it "has duplicated name in a group" do 
+        let(:second_task) { create :task, name: subject.name, group: subject.group}
+        expect(second_task).to_not be_valid
       end
     end
 

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Groups", type: :request do
 
   describe "POST /create" do
     # CALL PARAMS: {"group": {"name": ..., "description": ...}}
-    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was succesfully created"}
+    # 2xx RESPONSE: {"id": group_id, group: group_instance, "message": "The group was succesfully created"}
     # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be created"}
     before do
       sign_in user
@@ -68,8 +68,8 @@ RSpec.describe "Groups", type: :request do
       it "returns a json with the updated info of the user groups" do
         json = JSON.parse(response.body)
 
-        expect(json.groups.length).to eq 2
-        expect(json.groups.last.name).to eq("Spec Group")
+        expect(json.group.keys).to contain_exactly('id', 'name', 'description', 'admin_id')
+        expect(json.group.name).to eq("Spec Group")
         expect(json.message).to eq("The group was succesfully created")
       end
 
@@ -102,7 +102,7 @@ RSpec.describe "Groups", type: :request do
 
   describe "PATCH /update" do
     # CALL PARAMS: {"group": {"name": ..., "description": ...}}
-    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was succesfully updated"}
+    # 2xx RESPONSE: {"id": group_id, groups: group_instance, "message": "The group was succesfully updated"}
     # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be updated"}
     # 4xx RESPONSE: {"id": group_id, "message": "You don't have authorization to update the group"}
     context "when user is admin" do
@@ -128,8 +128,8 @@ RSpec.describe "Groups", type: :request do
         it "returns a json with the updated info of the user groups" do
           json = JSON.parse(response.body)
 
-          expect(json.groups.first).to eq 1
-          expect(json.groups.first.name).to eq("Updated Group")
+          expect(json.group.keys).to contain_exactly('id', 'name', 'description', 'admin_id')
+          expect(json.group.name).to eq("Updated Group")
           expect(json.message).to eq("The group was succesfully updated")
         end
       end
@@ -182,7 +182,7 @@ RSpec.describe "Groups", type: :request do
 
   describe "DELETE /destroy" do
     # CALL PARAMS: {"group": {"name": ..., "description": ...}}
-    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was successfully deleted"}
+    # 2xx RESPONSE: {"id": group_id, "message": "The group was successfully deleted"}
     # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be deleted"}
     context "when user is admin" do
       before do
@@ -199,7 +199,6 @@ RSpec.describe "Groups", type: :request do
       it "returns a json with the updated info of the user groups" do
         json = JSON.parse(response.body)
 
-        expect(json.groups.length).to eq 0
         expect(json.message).to eq("The group was succesfully deleted")
       end
     end

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+RSpec.describe "Groups", type: :request do
+
+  describe "GET /index" do
+    expect(response).to have_http_status(:success)
+    it "returns a json with the groups of the user" do
+    end
+  end
+
+  describe "GET /show" do
+    expect(response).to have_http_status(:success)
+    it "returns a json with a specific group of the user" do
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      expect(response).to have_http_status(:success)
+      it "creates the group" do
+         # Here we check the creation happened
+      end
+
+      it "returns a json with the info of the new group" do
+      end
+
+      it "has the user set as the admin" do
+      end
+    end
+
+    context "with invalid parameters" do
+      expect(response).to have_http_status(:error)
+      it "does not create the group" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "when user is admin" do
+      context "with valid parameters" do
+        expect(response).to have_http_status(:success)
+        it "updates the group" do
+        end
+
+        it "returns a json with the info of the new group" do
+        end
+      end
+
+      context "with invalid parameters" do
+        expect(response).to have_http_status(:error)
+        it "does not create the group" do
+        end
+
+        it "returns a json with an error message" do
+        end
+      end
+    end
+
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "does not create the group" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    context "when user is admin" do
+      expect(response).to have_http_status(:success)
+      it "deletes the group" do
+        # Memberships, tags, tasks, taggedtasks, invitations
+      end
+
+      it "deletes the group's dependent associations" do
+      end
+
+      it "returns a json with updated info of user groups" do
+      end
+    end
+
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "does not delete the group" do
+      end
+
+      it "does not delete the group's dependent associations" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "GET /filter_tasks" do
+    let(:tasks) { create_list(:task, 3)}
+
+    sign_in user
+    context "when filter param is empty" do
+      # params[:query] -> {name: "", assignee: "", finished: "true or false", due_date: ""}
+      get filter_tasks_api_v1_user(group.id)
+
+      expect(response).to have_http_status(:success)
+      it "returns an array of all tasks for that group" do
+        json = JSON.parse(response.body)
+        # {id: group_id, tasks: [task_instances]}
+
+      end
+    end
+
+    context "when filter param has only one param" do
+      it "returns an array the tasks that fit the search in the group" do
+
+      end
+    end
+
+    context "when filter param has more than one param" do
+      it "returns an array the tasks that fit the search in the group" do
+ 
+      end
+    end
+  end
+
+  describe "POST /send_invitation" do
+    context "when user is admin" do
+      expect(response).to have_http_status(:success)
+      it "enqueues an invitation" do
+      end
+
+      it "returns a json with a success message" do
+      end
+    end
+
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "does not enqueue any invitation" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "GET /fetch_group_users" do
+    expect(response).to have_http_status(:success)
+    it "returns a json with the users in the group" do
+    end
+  end
+
+  describe "DELETE /remove_user" do
+    context "when user is admin" do
+      expect(response).to have_http_status(:success)
+      it "deletes the user" do
+      end
+
+      it "changes the ownership of user's tasks to group admin" do
+      end
+
+      it "changes the ownership of user's tags to group admin" do
+      end
+
+      it "returns a json with the updated list of users in the group" do
+      end
+    end
+
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "does not delete the user" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+end

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Groups", type: :request do
     end
 
     it { expect(response).to have_http_status(:success) }
+
     it "returns a json with a specific group of the user" do
       json = JSON.parse(response.body)
 
@@ -59,6 +60,7 @@ RSpec.describe "Groups", type: :request do
       end
 
       it { expect(response).to have_http_status(:success) }
+
       it "creates the group" do
         expect(Group.find_by(name: "Spec Group")).to be_present
       end
@@ -66,7 +68,7 @@ RSpec.describe "Groups", type: :request do
       it "returns a json with the updated info of the user groups" do
         json = JSON.parse(response.body)
 
-        expect(json.groups.count).to eq 2
+        expect(json.groups.length).to eq 2
         expect(json.groups.last.name).to eq("Spec Group")
         expect(json.message).to eq("The group was succesfully created")
       end
@@ -118,6 +120,7 @@ RSpec.describe "Groups", type: :request do
         end
 
         it { expect(response).to have_http_status(:success) }
+
         it "updates the group" do
           expect(group.name).to eq("Updated Group")
         end
@@ -139,6 +142,7 @@ RSpec.describe "Groups", type: :request do
         end
 
         it { expect(response).to have_http_status(:error) }
+
         it "does not create the group" do
           expect(group.name).to_not eq("a")
         end
@@ -195,7 +199,7 @@ RSpec.describe "Groups", type: :request do
       it "returns a json with the updated info of the user groups" do
         json = JSON.parse(response.body)
 
-        expect(json.groups.count).to eq 0
+        expect(json.groups.length).to eq 0
         expect(json.message).to eq("The group was succesfully deleted")
       end
     end
@@ -232,7 +236,7 @@ RSpec.describe "Groups", type: :request do
       it "returns an array of all tasks for that group" do
         json = JSON.parse(response.body)
 
-        expect(json.task.count).to eq 3
+        expect(json.task.length).to eq 3
       end
     end
 
@@ -249,7 +253,7 @@ RSpec.describe "Groups", type: :request do
       it "returns an array the tasks that fit the search in the group" do
         json = JSON.parse(response.body)
 
-        expect(json.task.count).to eq 1
+        expect(json.task.length).to eq 1
       end
     end
 
@@ -266,7 +270,7 @@ RSpec.describe "Groups", type: :request do
       it "returns an array the tasks that fit the search in the group" do
         json = JSON.parse(response.body)
 
-        expect(json.task.count).to eq 2
+        expect(json.task.length).to eq 2
       end
     end
   end

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -1,195 +1,463 @@
 require 'rails_helper'
 
 RSpec.describe "Groups", type: :request do
+  # This creates a group with an admin on one side (and all associations in the Factory model) 
+  # and also a user that is then added to the group
+  let(:group) { create :group }
   let(:user) { create :user }
+  let!(:membership) {create :membership, user: user, group: group}
 
   describe "GET /index" do
+    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances]}
     before do
       sign_in user
       get api_v1_groups_path
     end
 
-    it "returns a json with the groups of the user" do
-      expect(response).to have_http_status(:success)
+    it { expect(response).to have_http_status(:success) }
+
+    it "returns a json with the info of the groups" do
       json = JSON.parse(response.body)
 
-      puts "JSON: #{json}"
-    end
-
-    it "returns a json with the groups of the user" do
-      expect(response).to have_http_status(:success)
-      json = JSON.parse(response.body)
-
-      puts "JSON: #{json}"
+      expect(json.groups.length).to eq 1
+      expect(json.groups.first.name).to eq(group.name)
     end
   end
 
-  # describe "GET /show" do
-  #   expect(response).to have_http_status(:success)
-  #   it "returns a json with a specific group of the user" do
-  #   end
-  # end
+  describe "GET /show" do
+    # PARAMS: params[:id]
+    # 2xx RESPONSE: {"id": group_id, "group": group_instance}
+    before do
+      sign_in user
+      get api_v1_group_path(group.id)
+    end
 
-  # describe "POST /create" do
-  #   context "with valid parameters" do
-  #     expect(response).to have_http_status(:success)
-  #     it "creates the group" do
-  #        # Here we check the creation happened
-  #     end
+    it { expect(response).to have_http_status(:success) }
+    it "returns a json with a specific group of the user" do
+      json = JSON.parse(response.body)
 
-  #     it "returns a json with the info of the new group" do
-  #     end
+      expect(json.group.keys).to contain_exactly('id', 'name', 'description', 'admin_id')
+      expect(json.group.name).to eq(group.name)
+    end
+  end
 
-  #     it "has the user set as the admin" do
-  #     end
-  #   end
+  describe "POST /create" do
+    # CALL PARAMS: {"group": {"name": ..., "description": ...}}
+    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was succesfully created"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be created"}
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
 
-  #   context "with invalid parameters" do
-  #     expect(response).to have_http_status(:error)
-  #     it "does not create the group" do
-  #     end
+    context "with valid parameters" do 
+      before do
+        post api_v1_groups_path, 
+        params: '{ "group": { "name": "Spec Group", "description": "This is a spec group" } }', 
+        headers: auth_headers
+      end
 
-  #     it "returns a json with an error message" do
-  #     end
-  #   end
-  # end
+      it { expect(response).to have_http_status(:success) }
+      it "creates the group" do
+        expect(Group.find_by(name: "Spec Group")).to be_present
+      end
 
-  # describe "PATCH /update" do
-  #   context "when user is admin" do
-  #     context "with valid parameters" do
-  #       expect(response).to have_http_status(:success)
-  #       it "updates the group" do
-  #       end
+      it "returns a json with the updated info of the user groups" do
+        json = JSON.parse(response.body)
 
-  #       it "returns a json with the info of the new group" do
-  #       end
-  #     end
+        expect(json.groups.count).to eq 2
+        expect(json.groups.last.name).to eq("Spec Group")
+        expect(json.message).to eq("The group was succesfully created")
+      end
 
-  #     context "with invalid parameters" do
-  #       expect(response).to have_http_status(:error)
-  #       it "does not create the group" do
-  #       end
+      it "has the user set as the admin" do
+        json = JSON.parse(response.body)
 
-  #       it "returns a json with an error message" do
-  #       end
-  #     end
-  #   end
+        expect(json.group.admin.id).to eq(user.id)
+      end
+    end
 
-  #   context "when user is not admin" do
-  #     expect(response).to have_http_status(:error)
-  #     it "does not create the group" do
-  #     end
+    context "with invalid parameters" do 
+      before do
+        post api_v1_groups_path, 
+        params: '{ "group": { "name": "a", "description": "This is a spec 2 group" } }', 
+        headers: auth_headers
+      end
 
-  #     it "returns a json with an error message" do
-  #     end
-  #   end
-  # end
+      it { expect(response).to have_http_status(:error) }
+      it "does not creates the group" do
+        expect(Group.find_by(name: "a")).to_not be_present
+      end
 
-  # describe "DELETE /destroy" do
-  #   context "when user is admin" do
-  #     expect(response).to have_http_status(:success)
-  #     it "deletes the group" do
-  #       # Memberships, tags, tasks, taggedtasks, invitations
-  #     end
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
 
-  #     it "deletes the group's dependent associations" do
-  #     end
+        expect(json.message).to eq("The group couldn't be created")
+      end
+    end
+  end
 
-  #     it "returns a json with updated info of user groups" do
-  #     end
-  #   end
+  describe "PATCH /update" do
+    # CALL PARAMS: {"group": {"name": ..., "description": ...}}
+    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was succesfully updated"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be updated"}
+    # 4xx RESPONSE: {"id": group_id, "message": "You don't have authorization to update the group"}
+    context "when user is admin" do
+      before do
+        sign_in group.admin
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+        auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, group.admin)
+      end
 
-  #   context "when user is not admin" do
-  #     expect(response).to have_http_status(:error)
-  #     it "does not delete the group" do
-  #     end
+      context "with valid parameters" do
+        before do
+          patch api_v1_group_path(group.id), 
+          params: '{"group": {"name": "Updated Group"}}', 
+          headers: auth_headers
+        end
 
-  #     it "does not delete the group's dependent associations" do
-  #     end
+        it { expect(response).to have_http_status(:success) }
+        it "updates the group" do
+          expect(group.name).to eq("Updated Group")
+        end
 
-  #     it "returns a json with an error message" do
-  #     end
-  #   end
-  # end
+        it "returns a json with the updated info of the user groups" do
+          json = JSON.parse(response.body)
 
-  # describe "GET /filter_tasks" do
-  #   let(:tasks) { create_list(:task, 3)}
+          expect(json.groups.first).to eq 1
+          expect(json.groups.first.name).to eq("Updated Group")
+          expect(json.message).to eq("The group was succesfully updated")
+        end
+      end
 
-  #   sign_in user
-  #   context "when filter param is empty" do
-  #     # params[:query] -> {name: "", assignee: "", finished: "true or false", due_date: ""}
-  #     get filter_tasks_api_v1_user(group.id)
+      context "with invalid parameters" do
+        before do
+          patch api_v1_group_path(group.id), 
+          params: '{"group": {"name": "a"}}', 
+          headers: auth_headers
+        end
 
-  #     expect(response).to have_http_status(:success)
-  #     it "returns an array of all tasks for that group" do
-  #       json = JSON.parse(response.body)
-  #       # {id: group_id, tasks: [task_instances]}
+        it { expect(response).to have_http_status(:error) }
+        it "does not create the group" do
+          expect(group.name).to_not eq("a")
+        end
 
-  #     end
-  #   end
+        it "returns a json with an error message" do
+          json = JSON.parse(response.body)
 
-  #   context "when filter param has only one param" do
-  #     it "returns an array the tasks that fit the search in the group" do
+          expect(json.message).to eq("The group couldn't be updated")
+        end
+      end
+    end
 
-  #     end
-  #   end
+    context "when user is not admin" do
+      before do
+        sign_in user
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+        auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+      end
 
-  #   context "when filter param has more than one param" do
-  #     it "returns an array the tasks that fit the search in the group" do
- 
-  #     end
-  #   end
-  # end
+      expect{
+        patch api_v1_group_path(group.id), 
+        params: '{"group": {"name": "Spec Group"}}', 
+        headers: auth_headers
+      }.to have_http_status(:error)
 
-  # describe "POST /send_invitation" do
-  #   context "when user is admin" do
-  #     expect(response).to have_http_status(:success)
-  #     it "enqueues an invitation" do
-  #     end
+      it "does not update the group" do
+        expect(group.name).to_not eq("Spec Group")
+      end
 
-  #     it "returns a json with a success message" do
-  #     end
-  #   end
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
 
-  #   context "when user is not admin" do
-  #     expect(response).to have_http_status(:error)
-  #     it "does not enqueue any invitation" do
-  #     end
+        expect(json.message).to eq("You don't have authorization to update the group")
+      end
+    end
+  end
 
-  #     it "returns a json with an error message" do
-  #     end
-  #   end
-  # end
+  describe "DELETE /destroy" do
+    # CALL PARAMS: {"group": {"name": ..., "description": ...}}
+    # 2xx RESPONSE: {"id": group_id, "groups": [group_instances], "message": "The group was successfully deleted"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The group couldn't be deleted"}
+    context "when user is admin" do
+      before do
+        sign_in group.admin
+        delete api_v1_group_path(group.id)
+      end
 
-  # describe "GET /fetch_group_users" do
-  #   expect(response).to have_http_status(:success)
-  #   it "returns a json with the users in the group" do
-  #   end
-  # end
+      it { expect(response).to have_http_status(:success) }
 
-  # describe "DELETE /remove_user" do
-  #   context "when user is admin" do
-  #     expect(response).to have_http_status(:success)
-  #     it "deletes the user" do
-  #     end
+      it "deletes the group" do
+        expect(Group.find(group.id)).to_not be_present
+      end
 
-  #     it "changes the ownership of user's tasks to group admin" do
-  #     end
+      it "deletes the group's dependent associations" do
+        expect(Task.where(group: group).count).to eq 0
+        expect(Tag.where(group: group).count).to eq 0
+        expect(Invitation.where(group: group).count).to eq 0
+        expect(Membership.where(group: group).count).to eq 0
+      end
 
-  #     it "changes the ownership of user's tags to group admin" do
-  #     end
+      it "returns a json with the updated info of the user groups" do
+        json = JSON.parse(response.body)
 
-  #     it "returns a json with the updated list of users in the group" do
-  #     end
-  #   end
+        expect(json.groups.count).to eq 0
+        expect(json.message).to eq("The group was succesfully deleted")
+      end
+    end
 
-  #   context "when user is not admin" do
-  #     expect(response).to have_http_status(:error)
-  #     it "does not delete the user" do
-  #     end
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "does not delete the group" do
+        expect(Group.find(group.id)).to be_present
+      end
 
-  #     it "returns a json with an error message" do
-  #     end
-  #   end
-  # end
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The group couldn't be deleted")
+      end
+    end
+  end
+
+  describe "GET /filter_tasks" do
+    # CALL PARAMS: {"task": {"name": "", "assignee": "", "finished": "true or false", "due_date": ""}}
+    # 2xx RESPONSE: {"id": group_id, "tasks": [group_instances]}
+
+    before do
+      sign_in user
+    end
+
+    context "when filter param is empty" do
+      before do
+        get filter_tasks_api_v1_group_path(group.id)
+      end
+      
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns an array of all tasks for that group" do
+        json = JSON.parse(response.body)
+
+        expect(json.task.count).to eq 3
+      end
+    end
+
+    context "when filter param has only one param" do
+      let!(:task) {create :task, group: group, finished: true}
+
+      before do
+        get filter_tasks_api_v1_group_path(group.id),
+        params: '{"task": {"name": "", "assignee": "", "finished": "true", "due_date": ""}', 
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns an array the tasks that fit the search in the group" do
+        json = JSON.parse(response.body)
+
+        expect(json.task.count).to eq 1
+      end
+    end
+
+    context "when filter param has more than one param" do
+      let!(:task) {create_list :task, group: group, finished: true, 2}
+
+      before do
+        get filter_tasks_api_v1_group_path(group.id),
+        params: '{"task": {"name": "Factory task", "assignee": "", "finished": "true", "due_date": "24/07/2050"}', 
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns an array the tasks that fit the search in the group" do
+        json = JSON.parse(response.body)
+
+        expect(json.task.count).to eq 2
+      end
+    end
+  end
+
+  describe "POST /send_invitation" do
+    # PARAMS: params[:group_id] && '{"group": {"email": "xxxx@test.io"}}'
+    # 2xx RESPONSE: {"id": group_id, "message": "The invitation was successfully created and enqueued"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The invitation couldn't be created"}
+
+    context "when user is admin" do
+      let(:parameterized_mailer) { double('ActionMailer::Parameterized::Mailer') }
+      let(:parameterized_message) { double('ActionMailer::Parameterized::MessageDelivery') }
+
+      before do
+        sign_in group.admin
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+        auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, group.admin)
+
+        allow(InvitationMailer).to receive(:with).and_return(parameterized_mailer)
+        allow(parameterized_mailer).to receive(:user_registration_email).and_return(parameterized_message)
+        allow(parameterized_message).to receive(:deliver_later)
+      end
+
+      context "when valid params" do
+        before do 
+          post send_invitation_api_v1_group_path(group.id),
+          params: '{ "group": { "email": "test@test.io" } }', 
+          headers: auth_headers
+        end
+  
+        it { expect(response).to have_http_status(:success) }
+
+        it "creates an invitation" do
+          expect(Invitation.find_by(email: "test@test.io")).to be_present
+        end
+  
+        it "enqueues an invitation" do
+          expect(InvitationMailer).to have_received(:with).with(recipient: "test@test.io", sender: group.email, group: group)
+          expect(parameterized_mailer).to have_received(:send_invite)
+          expect(parameterized_message).to have_received(:deliver_later)
+        end
+  
+        it "returns a json with a success message" do
+          json = JSON.parse(response.body)
+
+          expect(json.message).to eq("The invitation was successfully created and enqueued")
+        end
+      end
+
+      context "when invalid params" do
+        before do
+          post send_invitation_api_v1_group_path(group.id),
+          params: '{ "group": { "email": "test.io" } }', 
+          headers: auth_headers
+        end
+
+        it { expect(response).to have_http_status(:error) }
+
+        it "does not create any invitation" do
+          expect(Invitation.find_by(email: "test.io")).to_not be_present
+        end
+
+        it "does not enqueue any invitation" do
+          expect(InvitationMailer).to_not have_received(:with).with(recipient: "test.io", sender: group.email, group: group)
+          expect(parameterized_mailer).to_not have_received(:send_invite)
+          expect(parameterized_message).to_not have_received(:deliver_later)
+        end
+
+        it "returns a json with an error message" do
+          json = JSON.parse(response.body)
+
+          expect(json.message).to eq("The invitation couldn't be created")
+        end
+      end
+    end
+
+    context "when user is not admin" do
+      before do
+        sign_in user
+        headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+        auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+
+        post send_invitation_api_v1_group_path(group.id),
+        params: '{ "group": { "email": "test@test.io" } }',
+        headers: auth_headers
+      end
+
+      it { expect(response).to have_http_status(:error) }
+
+      it "does not create any invitation" do
+        expect(Invitation.find_by(email: "test@test.io")).to_not be_present
+      end
+
+      it "does not enqueue any invitation" do
+        expect(InvitationMailer).to_not have_received(:with).with(recipient: "test@test.io", sender: group.email, group: group)
+        expect(parameterized_mailer).to_not have_received(:send_invite)
+        expect(parameterized_message).to_not have_received(:deliver_later)
+      end
+
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The invitation couldn't be created")
+      end
+    end
+  end
+
+  describe "GET /fetch_group_users" do
+    # PARAMS: params[:group_id]
+    # 2xx RESPONSE: {"id": group_id, "users": [user_instances]}
+
+    before do
+      sign_in user
+      get fetch_group_users_api_v1_group_path(group.id)
+    end
+
+    it { expect(response).to have_http_status(:success) }
+
+    it "returns a json with the users in the groups" do
+      json = JSON.parse(response.body)
+
+      expect(json.users.length).to eq 2
+    end
+  end
+
+  describe "DELETE /remove_user" do
+    # PARAMS: params[:group_id, :user_id]
+    # 2xx RESPONSE: {"id": group_id, "user": [user_instances] , "message": "The user was successfully removed"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The user couldn't be removed"}
+    let(:new_user) {create :user}
+
+    before do
+      create(:task, name: "User task", user: user, group: group)
+      create(:tag, name: "User tag", user: user, group: group)
+      create(:membership, user: new_user, group: group)
+    end
+
+    context "when user is admin" do
+      before do
+        sign_in group.admin
+        get remove_group_user_api_v1_group_path(group.id, user)
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "deletes the user" do
+        expect(Group.find(group.id).users.where(id: user.id).count).to eq 0
+      end
+
+      it "changes the ownership of user's tasks to group admin" do
+        expect(Task.where(group: g).and(Task.where(user: user)).count).to eq 0
+        expect(Task.where(group: g).and(Task.where(user: group.admin)).count).to eq 1
+      end
+
+      it "changes the ownership of user's tags to group admin" do
+        expect(Tag.where(group: g).and(Tag.where(user: user)).count).to eq 0
+        expect(Tag.where(group: g).and(Tag.where(user: group.admin)).count).to eq 1
+      end
+
+      it "returns a json with the updated list of users in the group" do
+        json = JSON.parse(response.body)
+
+        expect(json.users.length).to eq 2
+        expect(json.message).to eq("The user was successfully removed")
+      end
+    end
+
+    context "when user is not admin" do
+      before do
+        sign_in user
+        get remove_group_user_api_v1_group_path(group.id, new_user)
+      end
+
+      it { expect(response).to have_http_status(:error) }
+
+      it "does not delete the user" do
+        expect(Group.find(group.id).users.where(id: new_user.id).count).to eq 1
+      end
+
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The user couldn't be removed")
+      end
+    end
+  end
 end

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -1,179 +1,195 @@
 require 'rails_helper'
 
 RSpec.describe "Groups", type: :request do
+  let(:user) { create :user }
 
   describe "GET /index" do
-    expect(response).to have_http_status(:success)
+    before do
+      sign_in user
+      get api_v1_groups_path
+    end
+
     it "returns a json with the groups of the user" do
-    end
-  end
-
-  describe "GET /show" do
-    expect(response).to have_http_status(:success)
-    it "returns a json with a specific group of the user" do
-    end
-  end
-
-  describe "POST /create" do
-    context "with valid parameters" do
       expect(response).to have_http_status(:success)
-      it "creates the group" do
-         # Here we check the creation happened
-      end
+      json = JSON.parse(response.body)
 
-      it "returns a json with the info of the new group" do
-      end
-
-      it "has the user set as the admin" do
-      end
+      puts "JSON: #{json}"
     end
 
-    context "with invalid parameters" do
-      expect(response).to have_http_status(:error)
-      it "does not create the group" do
-      end
-
-      it "returns a json with an error message" do
-      end
-    end
-  end
-
-  describe "PATCH /update" do
-    context "when user is admin" do
-      context "with valid parameters" do
-        expect(response).to have_http_status(:success)
-        it "updates the group" do
-        end
-
-        it "returns a json with the info of the new group" do
-        end
-      end
-
-      context "with invalid parameters" do
-        expect(response).to have_http_status(:error)
-        it "does not create the group" do
-        end
-
-        it "returns a json with an error message" do
-        end
-      end
-    end
-
-    context "when user is not admin" do
-      expect(response).to have_http_status(:error)
-      it "does not create the group" do
-      end
-
-      it "returns a json with an error message" do
-      end
-    end
-  end
-
-  describe "DELETE /destroy" do
-    context "when user is admin" do
+    it "returns a json with the groups of the user" do
       expect(response).to have_http_status(:success)
-      it "deletes the group" do
-        # Memberships, tags, tasks, taggedtasks, invitations
-      end
+      json = JSON.parse(response.body)
 
-      it "deletes the group's dependent associations" do
-      end
-
-      it "returns a json with updated info of user groups" do
-      end
-    end
-
-    context "when user is not admin" do
-      expect(response).to have_http_status(:error)
-      it "does not delete the group" do
-      end
-
-      it "does not delete the group's dependent associations" do
-      end
-
-      it "returns a json with an error message" do
-      end
+      puts "JSON: #{json}"
     end
   end
 
-  describe "GET /filter_tasks" do
-    let(:tasks) { create_list(:task, 3)}
+  # describe "GET /show" do
+  #   expect(response).to have_http_status(:success)
+  #   it "returns a json with a specific group of the user" do
+  #   end
+  # end
 
-    sign_in user
-    context "when filter param is empty" do
-      # params[:query] -> {name: "", assignee: "", finished: "true or false", due_date: ""}
-      get filter_tasks_api_v1_user(group.id)
+  # describe "POST /create" do
+  #   context "with valid parameters" do
+  #     expect(response).to have_http_status(:success)
+  #     it "creates the group" do
+  #        # Here we check the creation happened
+  #     end
 
-      expect(response).to have_http_status(:success)
-      it "returns an array of all tasks for that group" do
-        json = JSON.parse(response.body)
-        # {id: group_id, tasks: [task_instances]}
+  #     it "returns a json with the info of the new group" do
+  #     end
 
-      end
-    end
+  #     it "has the user set as the admin" do
+  #     end
+  #   end
 
-    context "when filter param has only one param" do
-      it "returns an array the tasks that fit the search in the group" do
+  #   context "with invalid parameters" do
+  #     expect(response).to have_http_status(:error)
+  #     it "does not create the group" do
+  #     end
 
-      end
-    end
+  #     it "returns a json with an error message" do
+  #     end
+  #   end
+  # end
 
-    context "when filter param has more than one param" do
-      it "returns an array the tasks that fit the search in the group" do
+  # describe "PATCH /update" do
+  #   context "when user is admin" do
+  #     context "with valid parameters" do
+  #       expect(response).to have_http_status(:success)
+  #       it "updates the group" do
+  #       end
+
+  #       it "returns a json with the info of the new group" do
+  #       end
+  #     end
+
+  #     context "with invalid parameters" do
+  #       expect(response).to have_http_status(:error)
+  #       it "does not create the group" do
+  #       end
+
+  #       it "returns a json with an error message" do
+  #       end
+  #     end
+  #   end
+
+  #   context "when user is not admin" do
+  #     expect(response).to have_http_status(:error)
+  #     it "does not create the group" do
+  #     end
+
+  #     it "returns a json with an error message" do
+  #     end
+  #   end
+  # end
+
+  # describe "DELETE /destroy" do
+  #   context "when user is admin" do
+  #     expect(response).to have_http_status(:success)
+  #     it "deletes the group" do
+  #       # Memberships, tags, tasks, taggedtasks, invitations
+  #     end
+
+  #     it "deletes the group's dependent associations" do
+  #     end
+
+  #     it "returns a json with updated info of user groups" do
+  #     end
+  #   end
+
+  #   context "when user is not admin" do
+  #     expect(response).to have_http_status(:error)
+  #     it "does not delete the group" do
+  #     end
+
+  #     it "does not delete the group's dependent associations" do
+  #     end
+
+  #     it "returns a json with an error message" do
+  #     end
+  #   end
+  # end
+
+  # describe "GET /filter_tasks" do
+  #   let(:tasks) { create_list(:task, 3)}
+
+  #   sign_in user
+  #   context "when filter param is empty" do
+  #     # params[:query] -> {name: "", assignee: "", finished: "true or false", due_date: ""}
+  #     get filter_tasks_api_v1_user(group.id)
+
+  #     expect(response).to have_http_status(:success)
+  #     it "returns an array of all tasks for that group" do
+  #       json = JSON.parse(response.body)
+  #       # {id: group_id, tasks: [task_instances]}
+
+  #     end
+  #   end
+
+  #   context "when filter param has only one param" do
+  #     it "returns an array the tasks that fit the search in the group" do
+
+  #     end
+  #   end
+
+  #   context "when filter param has more than one param" do
+  #     it "returns an array the tasks that fit the search in the group" do
  
-      end
-    end
-  end
+  #     end
+  #   end
+  # end
 
-  describe "POST /send_invitation" do
-    context "when user is admin" do
-      expect(response).to have_http_status(:success)
-      it "enqueues an invitation" do
-      end
+  # describe "POST /send_invitation" do
+  #   context "when user is admin" do
+  #     expect(response).to have_http_status(:success)
+  #     it "enqueues an invitation" do
+  #     end
 
-      it "returns a json with a success message" do
-      end
-    end
+  #     it "returns a json with a success message" do
+  #     end
+  #   end
 
-    context "when user is not admin" do
-      expect(response).to have_http_status(:error)
-      it "does not enqueue any invitation" do
-      end
+  #   context "when user is not admin" do
+  #     expect(response).to have_http_status(:error)
+  #     it "does not enqueue any invitation" do
+  #     end
 
-      it "returns a json with an error message" do
-      end
-    end
-  end
+  #     it "returns a json with an error message" do
+  #     end
+  #   end
+  # end
 
-  describe "GET /fetch_group_users" do
-    expect(response).to have_http_status(:success)
-    it "returns a json with the users in the group" do
-    end
-  end
+  # describe "GET /fetch_group_users" do
+  #   expect(response).to have_http_status(:success)
+  #   it "returns a json with the users in the group" do
+  #   end
+  # end
 
-  describe "DELETE /remove_user" do
-    context "when user is admin" do
-      expect(response).to have_http_status(:success)
-      it "deletes the user" do
-      end
+  # describe "DELETE /remove_user" do
+  #   context "when user is admin" do
+  #     expect(response).to have_http_status(:success)
+  #     it "deletes the user" do
+  #     end
 
-      it "changes the ownership of user's tasks to group admin" do
-      end
+  #     it "changes the ownership of user's tasks to group admin" do
+  #     end
 
-      it "changes the ownership of user's tags to group admin" do
-      end
+  #     it "changes the ownership of user's tags to group admin" do
+  #     end
 
-      it "returns a json with the updated list of users in the group" do
-      end
-    end
+  #     it "returns a json with the updated list of users in the group" do
+  #     end
+  #   end
 
-    context "when user is not admin" do
-      expect(response).to have_http_status(:error)
-      it "does not delete the user" do
-      end
+  #   context "when user is not admin" do
+  #     expect(response).to have_http_status(:error)
+  #     it "does not delete the user" do
+  #     end
 
-      it "returns a json with an error message" do
-      end
-    end
-  end
+  #     it "returns a json with an error message" do
+  #     end
+  #   end
+  # end
 end

--- a/api/spec/requests/group_spec.rb
+++ b/api/spec/requests/group_spec.rb
@@ -192,13 +192,6 @@ RSpec.describe "Groups", type: :request do
         expect(Group.find(group.id)).to_not be_present
       end
 
-      it "deletes the group's dependent associations" do
-        expect(Task.where(group: group).count).to eq 0
-        expect(Tag.where(group: group).count).to eq 0
-        expect(Invitation.where(group: group).count).to eq 0
-        expect(Membership.where(group: group).count).to eq 0
-      end
-
       it "returns a json with the updated info of the user groups" do
         json = JSON.parse(response.body)
 
@@ -378,24 +371,6 @@ RSpec.describe "Groups", type: :request do
 
         expect(json.message).to eq("The invitation couldn't be created")
       end
-    end
-  end
-
-  describe "GET /fetch_group_users" do
-    # PARAMS: params[:group_id]
-    # 2xx RESPONSE: {"id": group_id, "users": [user_instances]}
-
-    before do
-      sign_in user
-      get fetch_group_users_api_v1_group_path(group.id)
-    end
-
-    it { expect(response).to have_http_status(:success) }
-
-    it "returns a json with the users in the groups" do
-      json = JSON.parse(response.body)
-
-      expect(json.users.length).to eq 2
     end
   end
 

--- a/api/spec/requests/invitation_spec.rb
+++ b/api/spec/requests/invitation_spec.rb
@@ -2,39 +2,78 @@ require 'rails_helper'
 
 RSpec.describe "Invitations", type: :request do
   describe "GET /index" do
-    context "when user is admin" do
-      expect(response).to have_http_status(:success)
-      it "returns a json with the invitations for the group" do
-      end
+    # PARAMS: params[:group_id]
+    # 2xx RESPONSE: {"id": group_id, "invitations": [invitation_instances]}
+    let(:group) { create :group }
+    let(:user) { create :user }
+
+    before do
+      sign_in user
+      get api_v1_group_invitation_path(group.id)
     end
 
-    context "when user is not admin" do
-      expect(response).to have_http_status(:error)
-      it "returns a json with an error message" do
-      end
+    it { expect(response).to have_http_status(:success) }
+
+    it "returns a json with the invitations in the groups" do
+      json = JSON.parse(response.body)
+
+      expect(json.invitations.length).to eq 1
     end
   end
 
   describe "GET /invitation_signup" do
+    # PARAMS: params[:group_id]
+    # 2xx RESPONSE: {"id": group_id, "invitations": [invitation_instances]}
+    # 4xx RESPONSE: {"id": group_id, "message": "The invitation has expired already"}
+    let(:invitation) {create :invitation}
+
     context "when invitation has been disabled" do
-      expect(response).to have_http_status(:error)
+      before do
+        invitation.disabled = true
+        invitation.save
+      end
+
+      expect {
+        get api_v1_path(invitation.oauth_token)
+      }.to have_http_status(:error)
+
       it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The invitation has expired already")
       end
     end
 
     context "when invitation not disabled" do
       context "when expiration date has already passed" do
-        expect(response).to have_http_status(:error)
+        before do
+          invitation.expiration_date = DateTime.now - 8
+          invitation.save
+        end
+  
+        expect {
+          get api_v1_path(invitation.oauth_token)
+        }.to have_http_status(:error)
+
         it "returns a json with an error message" do
+          json = JSON.parse(response.body)
+
+          expect(json.message).to eq("The invitation has expired already")
         end
       end
 
       context "when expiration date has still not passed" do
-        expect(response).to have_http_status(:success)
+        expect {
+          get api_v1_path(invitation.oauth_token)
+        }.to have_http_status(:success)
+
         it "disables the invitation" do
+          expect(invitation.disabled).to be true
         end
 
         it "redirects invitee to sign up page with group_id set" do
+          expect(session[:group]).to eq(invitation.group)
+          expect(response).to redirect_to(user_session_path)
         end
       end
     end

--- a/api/spec/requests/invitation_spec.rb
+++ b/api/spec/requests/invitation_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Invitations", type: :request do
+  describe "GET /index" do
+    context "when user is admin" do
+      expect(response).to have_http_status(:success)
+      it "returns a json with the invitations for the group" do
+      end
+    end
+
+    context "when user is not admin" do
+      expect(response).to have_http_status(:error)
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "GET /invitation_signup" do
+    context "when invitation has been disabled" do
+      expect(response).to have_http_status(:error)
+      it "returns a json with an error message" do
+      end
+    end
+
+    context "when invitation not disabled" do
+      context "when expiration date has already passed" do
+        expect(response).to have_http_status(:error)
+        it "returns a json with an error message" do
+        end
+      end
+
+      context "when expiration date has still not passed" do
+        expect(response).to have_http_status(:success)
+        it "disables the invitation" do
+        end
+
+        it "redirects invitee to sign up page with group_id set" do
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/invitation_spec.rb
+++ b/api/spec/requests/invitation_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe "Invitations", type: :request do
 
   describe "GET /invitation_signup" do
     # PARAMS: params[:group_id]
-    # 2xx RESPONSE: {"id": group_id, "invitations": [invitation_instances]}
-    # 4xx RESPONSE: {"id": group_id, "message": "The invitation has expired already"}
+    # 4xx RESPONSE: {"id": invitation_id, "message": "The invitation has expired already"}
     let(:invitation) {create :invitation}
 
     context "when invitation has been disabled" do

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Tags", type: :request do
+  describe "GET /index" do
+    expect(response).to have_http_status(:success)
+    it "returns a json with the tags of the user for that group" do
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      expect(response).to have_http_status(:success)
+      it "creates the tag for that group" do
+        # Here we check the creation happened
+      end
+
+      it "returns a json with the info of the new tag" do
+      end
+    end
+
+    context "with invalid parameters" do
+      expect(response).to have_http_status(:error)
+      it "does not create the tag" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      expect(response).to have_http_status(:success)
+      it "updates the tag" do
+      end
+
+      it "returns a json with the info of the new tag" do
+      end
+    end
+
+    context "with invalid parameters" do
+      expect(response).to have_http_status(:error)
+      it "does not update the tag" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    expect(response).to have_http_status(:success)
+    it "deletes the tag" do
+      
+    end
+
+    it "deletes the tag's dependent associations" do
+      # taggedtasks
+    end
+
+    it "returns a json with updated info of group tags" do
+    end
+  end
+end

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -1,64 +1,155 @@
 require 'rails_helper'
 
 RSpec.describe "Tags", type: :request do
+  # This creates a group with an admin on one side (and all associations in the Factory model) 
+  # and also a user that is then added to the group
+  let(:group) { create :group }
+  let(:user) { create :user }
+  let(:tag) { group.tags.first }
+  let!(:membership) {create :membership, user: user, group: group}
+
   describe "GET /index" do
-    expect(response).to have_http_status(:success)
-    it "returns a json with the tags of the user for that group" do
+    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances]}
+    before do
+      sign_in user
+      get api_v1_group_tags_path
+    end
+
+    it { expect(response).to have_http_status(:success) }
+
+    it "returns a json with the tags for that group" do
+      json = JSON.parse(response.body)
+
+      expect(json.tags.length).to eq 1
+      expect(json.tags.first.name).to eq(group.name)
     end
   end
 
   describe "POST /create" do
+    # CALL PARAMS: {"tag": {"name": ...}}
+    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances], "message": "The tag was succesfully created"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The tag couldn't be created"}
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
+
     context "with valid parameters" do
-      expect(response).to have_http_status(:success)
-      it "creates the tag for that group" do
-        # Here we check the creation happened
+      before do
+        post api_v1_group_tags_path, 
+        params: '{ "tag": { "name": "Spec Tag" } }', 
+        headers: auth_headers
       end
 
-      it "returns a json with the info of the new tag" do
+      it { expect(response).to have_http_status(:success) }
+
+      it "creates the tag for that group" do
+        expect(Tag.find_by(name: "Spec Tag")).to be_present
+      end
+
+      it "returns a json with the updated info of the group tags" do
+        json = JSON.parse(response.body)
+
+        expect(json.tags.length).to eq 2
+        expect(json.tags.last.name).to eq("Spec Tag")
+        expect(json.message).to eq("The tag was succesfully created")
       end
     end
 
     context "with invalid parameters" do
-      expect(response).to have_http_status(:error)
+      before do
+        post api_v1_group_tags_path, 
+        params: '{ "tag": { "name": "Lorem ipsum dolor sit amet" } }', 
+        headers: auth_headers
+      end
+
+      it { expect(response).to have_http_status(:error) }
+
       it "does not create the tag" do
+        expect(Tag.find_by(name: "Lorem ipsum dolor sit amet")).to_not be_present
       end
 
       it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The tag couldn't be created")
       end
     end
   end
 
   describe "PATCH /update" do
+    # CALL PARAMS: {"tag": {"name": ...}}
+    # 2xx RESPONSE: {"id": group_id, "tags": [group_instances], "message": "The tag was succesfully updated"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The tag couldn't be updated"}
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
+
     context "with valid parameters" do
-      expect(response).to have_http_status(:success)
-      it "updates the tag" do
+      before do
+        post api_v1_group_tag_path(group.id, tag.id), 
+        params: '{ "tag": { "name": "Spec Tag 2" } }', 
+        headers: auth_headers
       end
 
-      it "returns a json with the info of the new tag" do
+      it { expect(response).to have_http_status(:success) }
+
+      it "updates the tag" do
+        expect(tag.name).to eq("Spec Tag 2")
+      end
+
+      it "returns a json with the updated info of the group tags" do
+        json = JSON.parse(response.body)
+
+        expect(json.tags.length).to eq 1
+        expect(json.tags.first.name).to eq("Spec Tag 2")
+        expect(json.message).to eq("The tag was succesfully updated")
       end
     end
 
     context "with invalid parameters" do
-      expect(response).to have_http_status(:error)
+      before do
+        post api_v1_group_tag_path(group.id, tag.id), 
+        params: '{ "tag": { "name": "Lorem ipsum dolor sit amet" } }', 
+        headers: auth_headers
+      end
+
+      it { expect(response).to have_http_status(:error) }
+
       it "does not update the tag" do
+        expect(tag.name).to_not eq("Lorem ipsum dolor sit amet")
       end
 
       it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The tag couldn't be updated")
       end
     end
   end
 
   describe "DELETE /destroy" do
-    expect(response).to have_http_status(:success)
-    it "deletes the tag" do
-      
+    # CALL PARAMS: {"tag": {"group_id": ..., "tag_id": ...}}
+    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances], "message": "The tag was successfully deleted"}
+    before do
+      sign_in user
+      delete api_v1_group_tag_path(group.id, tag.id)
     end
 
-    it "deletes the tag's dependent associations" do
-      # taggedtasks
+    it { expect(response).to have_http_status(:success) }
+
+    it "deletes the tag" do
+      expect(Tag.find(tag.id)).to_not be_present
     end
 
     it "returns a json with updated info of group tags" do
+      json = JSON.parse(response.body)
+
+      expect(json.tags.length).to eq 0
+      expect(json.message).to eq("The tag was succesfully deleted")
     end
   end
 end

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Tags", type: :request do
 
   describe "POST /create" do
     # CALL PARAMS: {"tag": {"name": ...}}
-    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances], "message": "The tag was succesfully created"}
+    # 2xx RESPONSE: {"id": group_id, "tag": tag_instances, "message": "The tag was succesfully created"}
     # 4xx RESPONSE: {"id": group_id, "message": "The tag couldn't be created"}
     before do
       sign_in user
@@ -51,8 +51,8 @@ RSpec.describe "Tags", type: :request do
       it "returns a json with the updated info of the group tags" do
         json = JSON.parse(response.body)
 
-        expect(json.tags.length).to eq 2
-        expect(json.tags.last.name).to eq("Spec Tag")
+        expect(json.tag.keys).to contain_exactly('id', 'name', 'slug', 'user_id', 'group_id')
+        expect(json.tag.name).to eq("Spec Tag")
         expect(json.message).to eq("The tag was succesfully created")
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe "Tags", type: :request do
 
   describe "PATCH /update" do
     # CALL PARAMS: {"tag": {"name": ...}}
-    # 2xx RESPONSE: {"id": group_id, "tags": [group_instances], "message": "The tag was succesfully updated"}
+    # 2xx RESPONSE: {"id": group_id, "tag": tag_instance, "message": "The tag was succesfully updated"}
     # 4xx RESPONSE: {"id": group_id, "message": "The tag couldn't be updated"}
     before do
       sign_in user
@@ -104,8 +104,8 @@ RSpec.describe "Tags", type: :request do
       it "returns a json with the updated info of the group tags" do
         json = JSON.parse(response.body)
 
-        expect(json.tags.length).to eq 1
-        expect(json.tags.first.name).to eq("Spec Tag 2")
+        expect(json.tag.keys).to contain_exactly('id', 'name', 'slug', 'user_id', 'group_id')
+        expect(json.tag.name).to eq("Spec Tag 2")
         expect(json.message).to eq("The tag was succesfully updated")
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe "Tags", type: :request do
 
   describe "DELETE /destroy" do
     # CALL PARAMS: {"tag": {"group_id": ..., "tag_id": ...}}
-    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances], "message": "The tag was successfully deleted"}
+    # 2xx RESPONSE: {"id": group_id, "message": "The tag was successfully deleted"}
     before do
       sign_in user
       delete api_v1_group_tag_path(group.id, tag.id)
@@ -148,7 +148,6 @@ RSpec.describe "Tags", type: :request do
     it "returns a json with updated info of group tags" do
       json = JSON.parse(response.body)
 
-      expect(json.tags.length).to eq 0
       expect(json.message).to eq("The tag was succesfully deleted")
     end
   end

--- a/api/spec/requests/tag_spec.rb
+++ b/api/spec/requests/tag_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Tags", type: :request do
       json = JSON.parse(response.body)
 
       expect(json.tags.length).to eq 1
-      expect(json.tags.first.name).to eq(group.name)
+      expect(json.tags.first.name).to eq(tag.name)
     end
   end
 

--- a/api/spec/requests/task_spec.rb
+++ b/api/spec/requests/task_spec.rb
@@ -1,65 +1,158 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :request do
+  # This creates a group with an admin on one side (and all associations in the Factory model) 
+  # and also a user that is then added to the group
+  let(:group) { create :group }
+  let(:user) { create :user }
+  let!(:membership) {create :membership, user: user, group: group}
+  # This generates two type of tasks: one part of the group we will be using for the specs and another one part of another group
+  let(:group_task) { create :task, user: user, group: group }
+  let(:task) { create :task, user: user }
+
   describe "GET /index" do
+    # 2xx RESPONSE: {"id": group_id, "tags": [tag_instances]}
     context "when done from a specific group" do
-      expect(response).to have_http_status(:success)
-      it "returns a json with all the tasks of the user" do
+      before do
+        sign_in user
+        get api_v1_group_tasks_path(group.id)
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns a json with the tasks of the user for that group" do
+        json = JSON.parse(response.body)
+
+        expect(json.task.length).to eq 1
       end
     end
 
     context "when done from the user dashboard" do
-      expect(response).to have_http_status(:success)
-      it "returns a json with the tasks of the user for that group" do
+      before do
+        sign_in user
+        get api_v1_tasks_path
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns a json with all the tasks of the user" do
+        json = JSON.parse(response.body)
+
+        expect(json.tasks.length).to eq 2
       end
     end
   end
 
   describe "GET /show" do
-    expect(response).to have_http_status(:success)
+    # PARAMS: params[:id]
+    # 2xx RESPONSE: {"id": group_id, "task": task_instance}
+    before do
+      sign_in user
+      get api_v1_task_path(task.id)
+    end
+
+    it { expect(response).to have_http_status(:success) }
+
     it "returns a json with a specific task of the user" do
+      json = JSON.parse(response.body)
+
+      expect(json.task.keys).to contain_exactly('id', 'name', 'note', 'due_date', 'finished', 'user_id', 'group_id', 'assignee_id')
+      expect(json.task.name).to eq(task.name)
     end
   end
 
   describe "POST /create" do
+    # CALL PARAMS: {"task": {"name": ...}}
+    # 2xx RESPONSE: {"id": group_id, "task": task_instance, "message": "The task was succesfully created"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The task couldn't be created"}
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
+
     context "when done from a specific group" do
       context "with valid parameters" do
-        expect(response).to have_http_status(:success)
+        before do
+          post api_v1_group_tasks_path(group.id), 
+          params: '{ "task": { "name": "Spec Task", "note": "This is a note", "due_date": "10-12-2050" } }', 
+          headers: auth_headers
+        end
+
+        it { expect(response).to have_http_status(:success) }
+
         it "creates the task for that group" do
-          # Here we check the creation happened
+          expect(Task.find_by(name: "Spec Task")).to be_present
         end
   
-        it "returns a json with the info of the new task" do
+        it "returns a json with the updated info of the user tasks" do
+          json = JSON.parse(response.body)
+
+          expect(json.task.name).to eq("Spec Task")
+          expect(json.message).to eq("The task was succesfully created")
         end
       end
   
       context "with invalid parameters" do
-        expect(response).to have_http_status(:error)
+        before do
+          post api_v1_group_tasks_path(group.id), 
+          params: '{ "task": { "note": "This is a note", "due_date": "10-12-2050" } }', 
+          headers: auth_headers
+        end
+
+        it { expect(response).to have_http_status(:error) }
+
         it "does not create the task" do
+          expect(Task.find_by(name: "Spec Task")).to_not be_present
         end
   
         it "returns a json with an error message" do
+          json = JSON.parse(response.body)
+
+          expect(json.message).to eq("The task couldn't be created")
         end
       end
     end
 
     context "when done from the user dashboard" do
       context "with valid parameters" do
-        expect(response).to have_http_status(:success)
+        before do
+          post api_v1_tasks_path, 
+          params: "{ 'task': { 'name': 'Spec Task', 'note': 'This is a note', 'due_date': '10-12-2050', 'group_id': #{group.id} } }".to_json, 
+          headers: auth_headers
+        end
+
+        it { expect(response).to have_http_status(:success) }
+
         it "creates the task" do
-          # Here we check the creation happened
+          expect(Task.find_by(name: "Spec Task")).to be_present
         end
   
-        it "returns a json with the info of the new task" do
+        it "returns a json with the updated info of the user tasks in the group" do
+          json = JSON.parse(response.body)
+
+          expect(json.task.name).to eq("Spec Task")
+          expect(json.message).to eq("The task was succesfully created")
         end
       end
   
       context "with invalid parameters" do
-        expect(response).to have_http_status(:error)
+        before do
+          post api_v1_tasks_path, 
+          params: '{ "task": { "name": "Spec Task", "note": "This is a note", "due_date": "10-12-2050" } }', 
+          headers: auth_headers
+        end
+
+        it { expect(response).to have_http_status(:error) }
+
         it "does not create the task" do
+          expect(Task.find_by(name: "Spec Task")).to_not be_present
         end
   
         it "returns a json with an error message" do
+          json = JSON.parse(response.body)
+
+          expect(json.message).to eq("The task couldn't be created")
         end
       end
     end
@@ -67,36 +160,75 @@ RSpec.describe "Tasks", type: :request do
   end
 
   describe "PATCH /update" do
+    # CALL PARAMS: {"task": {"name": ...}}
+    # 2xx RESPONSE: {"id": group_id, "task": task_instance, "message": "The task was succesfully updated"}
+    # 4xx RESPONSE: {"id": group_id, "message": "The task couldn't be updated"}
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
+
     context "with valid parameters" do
-      expect(response).to have_http_status(:success)
-      it "updates the task" do
+      before do
+        post api_v1_task_path(task.id), 
+        params: '{ "task": { "name": "Spec Task 2" } }', 
+        headers: auth_headers
       end
 
-      it "returns a json with the info of the new task" do
+      it { expect(response).to have_http_status(:success) }
+
+      it "updates the task" do
+        expect(task.name).to eq("Spec Task 2")
+      end
+
+      it "returns a json with the updated info of the user tasks" do
+        json = JSON.parse(response.body)
+
+        expect(json.task.name).to eq("Spec Task 2")
+        expect(json.message).to eq("The task was succesfully updated")
       end
     end
 
     context "with invalid parameters" do
-      expect(response).to have_http_status(:error)
+      before do
+        post api_v1_task_path(task.id), 
+        params: '{ "task": { "note": "This is a note", "due_date": "10-12-2050" } }', 
+        headers: auth_headers
+      end
+
+      it { expect(response).to have_http_status(:error) }
+
       it "does not update the task" do
+        expect(task.note).to_not eq("This is a note")
       end
 
       it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The task couldn't be updated")
       end
     end
   end
 
   describe "DELETE /destroy" do
-    expect(response).to have_http_status(:success)
-    it "deletes the task" do
-      
+    # CALL PARAMS: {"tag": {"group_id": ..., "tag_id": ...}}
+    # 2xx RESPONSE: {"id": group_id, "message": "The tag was successfully deleted"}
+    before do
+      sign_in user
+      delete api_v1_tas_path(task.id)
     end
 
-    it "deletes the task's dependent associations" do
-      # taggedtasks
+    it { expect(response).to have_http_status(:success) }
+
+    it "deletes the task" do
+      expect(Task.find(task.id)).to_not be_present
     end
 
     it "returns a json with updated info of user tasks" do
+      json = JSON.parse(response.body)
+
+      expect(json.message).to eq("The tag was succesfully deleted")
     end
   end
 end

--- a/api/spec/requests/task_spec.rb
+++ b/api/spec/requests/task_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe "Tasks", type: :request do
+  describe "GET /index" do
+    context "when done from a specific group" do
+      expect(response).to have_http_status(:success)
+      it "returns a json with all the tasks of the user" do
+      end
+    end
+
+    context "when done from the user dashboard" do
+      expect(response).to have_http_status(:success)
+      it "returns a json with the tasks of the user for that group" do
+      end
+    end
+  end
+
+  describe "GET /show" do
+    expect(response).to have_http_status(:success)
+    it "returns a json with a specific task of the user" do
+    end
+  end
+
+  describe "POST /create" do
+    context "when done from a specific group" do
+      context "with valid parameters" do
+        expect(response).to have_http_status(:success)
+        it "creates the task for that group" do
+          # Here we check the creation happened
+        end
+  
+        it "returns a json with the info of the new task" do
+        end
+      end
+  
+      context "with invalid parameters" do
+        expect(response).to have_http_status(:error)
+        it "does not create the task" do
+        end
+  
+        it "returns a json with an error message" do
+        end
+      end
+    end
+
+    context "when done from the user dashboard" do
+      context "with valid parameters" do
+        expect(response).to have_http_status(:success)
+        it "creates the task" do
+          # Here we check the creation happened
+        end
+  
+        it "returns a json with the info of the new task" do
+        end
+      end
+  
+      context "with invalid parameters" do
+        expect(response).to have_http_status(:error)
+        it "does not create the task" do
+        end
+  
+        it "returns a json with an error message" do
+        end
+      end
+    end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      expect(response).to have_http_status(:success)
+      it "updates the task" do
+      end
+
+      it "returns a json with the info of the new task" do
+      end
+    end
+
+    context "with invalid parameters" do
+      expect(response).to have_http_status(:error)
+      it "does not update the task" do
+      end
+
+      it "returns a json with an error message" do
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    expect(response).to have_http_status(:success)
+    it "deletes the task" do
+      
+    end
+
+    it "deletes the task's dependent associations" do
+      # taggedtasks
+    end
+
+    it "returns a json with updated info of user tasks" do
+    end
+  end
+end

--- a/api/spec/requests/task_spec.rb
+++ b/api/spec/requests/task_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe "Tasks", type: :request do
         it "returns a json with the updated info of the user tasks" do
           json = JSON.parse(response.body)
 
+          expect(json.task.keys).to contain_exactly('id', 'name', 'note', 'due_date', 'finished', 'user_id', 'group_id', 'assignee_id')
           expect(json.task.name).to eq("Spec Task")
           expect(json.message).to eq("The task was succesfully created")
         end
@@ -131,6 +132,7 @@ RSpec.describe "Tasks", type: :request do
         it "returns a json with the updated info of the user tasks in the group" do
           json = JSON.parse(response.body)
 
+          expect(json.task.keys).to contain_exactly('id', 'name', 'note', 'due_date', 'finished', 'user_id', 'group_id', 'assignee_id')
           expect(json.task.name).to eq("Spec Task")
           expect(json.message).to eq("The task was succesfully created")
         end
@@ -185,6 +187,7 @@ RSpec.describe "Tasks", type: :request do
       it "returns a json with the updated info of the user tasks" do
         json = JSON.parse(response.body)
 
+        expect(json.task.keys).to contain_exactly('id', 'name', 'note', 'due_date', 'finished', 'user_id', 'group_id', 'assignee_id')
         expect(json.task.name).to eq("Spec Task 2")
         expect(json.message).to eq("The task was succesfully updated")
       end

--- a/api/spec/requests/user_spec.rb
+++ b/api/spec/requests/user_spec.rb
@@ -3,82 +3,100 @@ require 'devise/jwt/test_helpers'
 
 RSpec.describe "Users", type: :request do
   describe "GET /search_tasks" do
+    # CALL PARAMS: params[:query]
+    # 2xx RESPONSE: {"id": user_id, "tasks": [task_instances]}
+    # 4xx RESPONSE: {"id": user_id, "error": "The task you are searching doesn't exist"}
     let(:tasks) { create_list(:task, 3)}
     let(:user) { tasks.first.user }
 
-    sign_in user
+    before do
+      sign_in user
+    end
 
     context "when search param exactly exists in task name or note" do
-      # params[:query] -> string
-      get search_tasks_api_v1_user(user.id, tasks.first)
+      get api_v1_search_user_tasks(tasks.first.name)
 
       expect(response).to have_http_status(:success)
-      it "returns a json with the tasks for that user" do
+      it "returns a json with the user's tasks that matched the query" do
         json = JSON.parse(response.body)
-        # {'id': user_id, 'tasks': [task_instances]}
+
         expect(json.tasks.length).to eq 1
         expect(json.tasks.first["name"]).to include(tasks.first.name)
       end
     end
 
     context "when search param partially exists in task name or note" do
-      # params[:query] -> string
-      get search_tasks_api_v1_user(user.id, "Task")
+      get api_v1_search_user_tasks("Task")
 
       expect(response).to have_http_status(:success)
-      it "returns a json with the tasks for that user" do
+      it "returns a json with the user's tasks that matched the query" do
         json = JSON.parse(response.body)
-        # {'id': user_id, 'tasks': [task_instances]}
+        
         expect(json.tasks.length).to eq 3
       end
     end
 
     context "when search param doesn't exist in task name or note" do
-      # params[:query] -> string
-      get search_tasks_api_v1_user(user.id, "rand")
+      get api_v1_search_user_tasks("rand")
 
       expect(response).to have_http_status(:error)
       it "returns a json with an error message" do
         json = JSON.parse(response.body)
-        # {'id': user_id, 'error': "The task you are searching doesn't exist"}
+
         expect(json.error).to eq("The task you are searching doesn't exist")
-      end
-    end
-
-    context "when there are different users in the group" do
-      expect(response).to have_http_status(:success)
-      it "returns a json with only the tasks of the current user" do
-      end
-    end
-
-    context "when the current user belongs to different groups" do
-      expect(response).to have_http_status(:success)
-      it "returns a json with all the tasks of the current user" do
       end
     end
   end
 
   describe "PATCH /update" do
+    # CALL PARAMS: {"icon": {"id": new_icon_id}}
+    # 2xx RESPONSE: {"id": user_id, "data": {"username": ....}}
+    # 4xx RESPONSE: {"id": user_id, "error": "The user's icon couldn't be updated"}
+
+    let(:user) { create :user }
+    let(:new_icon) { create :icon }
+
+    before do
+      sign_in user
+      headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
+    end
+
     context "with valid parameters" do
-      expect(response).to have_http_status(:success)
+      expect{
+        patch api_v1_user, 
+        params: "{ 'icon': { 'id': #{new_icon.id} } }".to_json, 
+        headers: auth_headers
+      }.to have_http_status(:success)
+
       it "updates the user icon" do
-        # Here we check the update happened
+        expect(user.icon.id).to eq(new_icon.id)
       end
   
       it "returns a json with the updated user info" do
-        # {'id': user_id, 'data': {'username': ....}}
-  
+        json = JSON.parse(response.body)
+
+        expect(json.data.keys).to contain_exactly('id', 'username', 'email', 'icon_id')
+        expect(json.data.id).to eq(user.id)
+        expect(json.data.new_icon).to eq(new_icon.id)
       end
     end
 
     context "with invalid parameters" do
-      expect(response).to have_http_status(:error)
+      expect{
+        patch api_v1_user, 
+        params: '{ "icon": { "id": 100 } }', 
+        headers: auth_headers
+      }.to have_http_status(:error)
+
       it "does not update the user icon" do
+        expect(user.icon.id).to_not eq(new_icon.id)
       end
   
       it "returns a json with an error message" do
-        # {'id': user_id, 'error': "The task you are searching doesn't exist"}
+        json = JSON.parse(response.body)
   
+        expect(json.error).to eq("The user's icon couldn't be updated")
       end
     end
   end

--- a/api/spec/requests/user_spec.rb
+++ b/api/spec/requests/user_spec.rb
@@ -2,52 +2,23 @@ require 'rails_helper'
 require 'devise/jwt/test_helpers'
 
 RSpec.describe "Users", type: :request do
-  describe "GET /search_tasks" do
-    # CALL PARAMS: params[:query]
-    # 2xx RESPONSE: {"id": user_id, "tasks": [task_instances]}
-    # 4xx RESPONSE: {"id": user_id, "message": "The task you are searching doesn't exist"}
-    let(:tasks) { create_list(:task, 3)}
-    let(:user) { tasks.first.user }
+  describe "GET /index" do
+    # PARAMS: params[:group_id]
+    # 2xx RESPONSE: {"id": group_id, "users": [user_instances]}
+    let(:group) { create :group }
+    let(:user) { create :user }
 
     before do
       sign_in user
+      get api_v1_group_users_path(group.id)
     end
 
-    context "when search param exactly exists in task name or note" do
-      get api_v1_search_user_tasks_path(tasks.first.name)
+    it { expect(response).to have_http_status(:success) }
 
-      it { expect(response).to have_http_status(:success) }
+    it "returns a json with the users in the groups" do
+      json = JSON.parse(response.body)
 
-      it "returns a json with the user's tasks that matched the query" do
-        json = JSON.parse(response.body)
-
-        expect(json.tasks.length).to eq 1
-        expect(json.tasks.first["name"]).to eq(tasks.first.name)
-      end
-    end
-
-    context "when search param partially exists in task name or note" do
-      get api_v1_search_user_tasks_path("Task")
-
-      it { expect(response).to have_http_status(:success) }
-
-      it "returns a json with the user's tasks that matched the query" do
-        json = JSON.parse(response.body)
-        
-        expect(json.tasks.length).to eq 3
-      end
-    end
-
-    context "when search param doesn't exist in task name or note" do
-      get api_v1_search_user_tasks_path("rand")
-      
-      it { expect(response).to have_http_status(:error) }
-
-      it "returns a json with an error message" do
-        json = JSON.parse(response.body)
-
-        expect(json.message).to eq("The task you are searching doesn't exist")
-      end
+      expect(json.users.length).to eq 2
     end
   end
 
@@ -104,6 +75,55 @@ RSpec.describe "Users", type: :request do
         json = JSON.parse(response.body)
   
         expect(json.message).to eq("The user icon couldn't be updated")
+      end
+    end
+  end
+
+  describe "GET /search_tasks" do
+    # CALL PARAMS: params[:query]
+    # 2xx RESPONSE: {"id": user_id, "tasks": [task_instances]}
+    # 4xx RESPONSE: {"id": user_id, "message": "The task you are searching doesn't exist"}
+    let(:tasks) { create_list(:task, 3)}
+    let(:user) { tasks.first.user }
+
+    before do
+      sign_in user
+    end
+
+    context "when search param exactly exists in task name or note" do
+      get api_v1_search_user_tasks_path(tasks.first.name)
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns a json with the user's tasks that matched the query" do
+        json = JSON.parse(response.body)
+
+        expect(json.tasks.length).to eq 1
+        expect(json.tasks.first["name"]).to eq(tasks.first.name)
+      end
+    end
+
+    context "when search param partially exists in task name or note" do
+      get api_v1_search_user_tasks_path("Task")
+
+      it { expect(response).to have_http_status(:success) }
+
+      it "returns a json with the user's tasks that matched the query" do
+        json = JSON.parse(response.body)
+        
+        expect(json.tasks.length).to eq 3
+      end
+    end
+
+    context "when search param doesn't exist in task name or note" do
+      get api_v1_search_user_tasks_path("rand")
+      
+      it { expect(response).to have_http_status(:error) }
+
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+
+        expect(json.message).to eq("The task you are searching doesn't exist")
       end
     end
   end

--- a/api/spec/requests/user_spec.rb
+++ b/api/spec/requests/user_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+require 'devise/jwt/test_helpers'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /search_tasks" do
+    let(:tasks) { create_list(:task, 3)}
+    let(:user) { tasks.first.user }
+
+    sign_in user
+
+    context "when search param exactly exists in task name or note" do
+      # params[:query] -> string
+      get search_tasks_api_v1_user(user.id, tasks.first)
+
+      expect(response).to have_http_status(:success)
+      it "returns a json with the tasks for that user" do
+        json = JSON.parse(response.body)
+        # {'id': user_id, 'tasks': [task_instances]}
+        expect(json.tasks.length).to eq 1
+        expect(json.tasks.first["name"]).to include(tasks.first.name)
+      end
+    end
+
+    context "when search param partially exists in task name or note" do
+      # params[:query] -> string
+      get search_tasks_api_v1_user(user.id, "Task")
+
+      expect(response).to have_http_status(:success)
+      it "returns a json with the tasks for that user" do
+        json = JSON.parse(response.body)
+        # {'id': user_id, 'tasks': [task_instances]}
+        expect(json.tasks.length).to eq 3
+      end
+    end
+
+    context "when search param doesn't exist in task name or note" do
+      # params[:query] -> string
+      get search_tasks_api_v1_user(user.id, "rand")
+
+      expect(response).to have_http_status(:error)
+      it "returns a json with an error message" do
+        json = JSON.parse(response.body)
+        # {'id': user_id, 'error': "The task you are searching doesn't exist"}
+        expect(json.error).to eq("The task you are searching doesn't exist")
+      end
+    end
+
+    context "when there are different users in the group" do
+      expect(response).to have_http_status(:success)
+      it "returns a json with only the tasks of the current user" do
+      end
+    end
+
+    context "when the current user belongs to different groups" do
+      expect(response).to have_http_status(:success)
+      it "returns a json with all the tasks of the current user" do
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      expect(response).to have_http_status(:success)
+      it "updates the user icon" do
+        # Here we check the update happened
+      end
+  
+      it "returns a json with the updated user info" do
+        # {'id': user_id, 'data': {'username': ....}}
+  
+      end
+    end
+
+    context "with invalid parameters" do
+      expect(response).to have_http_status(:error)
+      it "does not update the user icon" do
+      end
+  
+      it "returns a json with an error message" do
+        # {'id': user_id, 'error': "The task you are searching doesn't exist"}
+  
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add specs for requests
- Update routes
- Update behavior of some models: group, task and tag so that associated instances will be removed in cascade
- Created factory bot for some middle models: membership and tagged task in order to use them for the request specs