### PR TITLE
fix: added delete icons to seeds

### DIFF
--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -27,6 +27,10 @@ Group.destroy_all
 puts "Destroy Users"
 User.destroy_all
 
+puts "Deleting all Icons"
+
+Icon.destroy_all
+
 puts "Creating Icons"
 
 default_icon = Icon::IMAGES[0]


### PR DESCRIPTION
Added `destroy_all` icon to the seeds so that when I seed the project, it cleans up the db