### PR TITLE
fix: updated the way we return the json to the frontend

### DIFF
--- a/api/app/controllers/api/v1/groups/tasks_controller.rb
+++ b/api/app/controllers/api/v1/groups/tasks_controller.rb
@@ -5,8 +5,8 @@ class Api::V1::Groups::TasksController < ApplicationController
   # Fetch all the tasks of an user in a group (whether the user is the creator or assignee)
   # GET /api/v1/groups/:group_id/tasks
   def index
-    @tasks = @group.tasks.where(user: current_user).or(Task.where(assignee: current_user)) # we don't need the auth check because we already fetch only the tasks in the group of the current user in the backend
-    render json: { task_value: build_json(@tasks) }
+    tasks = @group.tasks.where(user: current_user).or(Task.where(assignee: current_user)) # we don't need the auth check because we already fetch only the tasks in the group of the current user in the backend
+    render json: { task_value: divide_tasks_by_date(tasks) }
   end
 
   # Create a task in a group
@@ -43,5 +43,17 @@ class Api::V1::Groups::TasksController < ApplicationController
 
   def render_error(message, status)
     render json: {message: message}, status: status
+  end
+
+  def divide_tasks_by_date(tasks)
+    today = Date.today
+    upcoming_tasks = tasks.filter { |task| task.due_date > today }
+    past_tasks = tasks.filter { |task| task.due_date < today }
+    today_tasks = tasks.filter { |task| task.due_date == today }
+    {
+      today: build_json(today_tasks),
+      upcoming: build_json(upcoming_tasks),
+      past: build_json(past_tasks)
+    }
   end
 end

--- a/api/spec/requests/api/v1/groups/tasks_spec.rb
+++ b/api/spec/requests/api/v1/groups/tasks_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe "Api::V1::Groups::Tasks", type: :request do
   end
 
   describe "GET /index" do
-    # 2xx RESPONSE:  { "task_value": [{ "task": task_instance, "task_tags": [task_instance.tags] }, {...}] }
+    # 2xx RESPONSE:  { "task_value": {
+    #                                  "today: [{ "task": task_instance, "task_tags": [task_instance.tags] },...],
+    #                                  "upcoming: [{ "task": task_instance, "task_tags": [task_instance.tags] },...],
+    #                                  "past: [{ "task": task_instance, "task_tags": [task_instance.tags] },...],
+    #                                }
+    #                }
     before do
       sign_in user
       get api_v1_group_tasks_path(group.id)
@@ -24,15 +29,16 @@ RSpec.describe "Api::V1::Groups::Tasks", type: :request do
     it "returns a json with the tasks of the user for that group" do
       json = JSON.parse(response.body)
 
-      expect(json["task_value"].length).to eq 1
-      expect(json["task_value"].first["task"]["name"]).to eq(group_task.name)
+      expect(json["task_value"]).to have_key("today").and have_key("upcoming").and have_key("past")
+      expect([json["task_value"]["today"], json["task_value"]["past"]]).to all(be_empty)
+      expect(json["task_value"]["upcoming"].length).to eq 1
     end
 
     it "returns a json with all the tags of each task" do
       json = JSON.parse(response.body)
 
-      expect(json["task_value"].first["task_tags"].count).to eq 1
-      expect(json["task_value"].first["task_tags"].first["name"]).to eq(tags.first.name)
+      expect(json["task_value"]["upcoming"].first["task_tags"].count).to eq 1
+      expect(json["task_value"]["upcoming"].first["task_tags"].first["name"]).to eq(tags.first.name)
     end
   end
 


### PR DESCRIPTION
- Created a json that divides the user tasks for a group into `upcoming` tasks, `today` tasks and `past` tasks. We use the `due_date` column of the `task` instance to make it happen. 
This will make it easier to work with the tasks in the frontend the way we want.
- Updated specs